### PR TITLE
refactor(templates): remove old templates from app config

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -125,11 +125,6 @@ catalog:
         - allow: [ Template ]
 
     - type: url
-      target: https://github.com/sourcefuse/sf-software-templates/blob/main/scaffolder-templates/react-boilerplate/template.yaml
-      rules:
-        - allow: [ Template ]
-
-    - type: url
       target: https://github.com/sourcefuse/sf-software-templates/blob/main/scaffolder-templates/terraform-aws-ref-arch-bootstrap/template.yaml
       rules:
         - allow: [ Template ]
@@ -198,11 +193,6 @@ catalog:
 
     - type: url
       target: https://github.com/sourcefuse/terraform-aws-arc-eks/blob/main/catalog-info.yml
-      rules:
-        - allow: [ Component ]
-
-    - type: url
-      target: https://github.com/sourcefuse/terraform-aws-arc-bootstrap/blob/main/catalog-info.yml
       rules:
         - allow: [ Component ]
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -125,11 +125,6 @@ catalog:
         - allow: [ Template ]
 
     - type: url
-      target: https://github.com/sourcefuse/sf-software-templates/blob/main/scaffolder-templates/terraform-aws-ref-arch-bootstrap/template.yaml
-      rules:
-        - allow: [ Template ]
-
-    - type: url
       target: https://github.com/sourcefuse/sf-software-templates/blob/main/scaffolder-templates/microservice-repo-bootstrap/template.yaml
       rules:
         - allow: [ Template ]
@@ -155,11 +150,6 @@ catalog:
       rules:
         - allow: [ Component ]
       tags: [ Backend ]
-
-    - type: url
-      target: https://github.com/sourcefuse/terraform-aws-ref-arch-bootstrap/blob/main/catalog-info.yaml
-      rules:
-        - allow: [ Component ]
 
     - type: url
       target: https://github.com/sourcefuse/terraform-aws-arc-db/blob/main/catalog-info.yaml

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -187,6 +187,11 @@ catalog:
         - allow: [ Component ]
 
     - type: url
+      target: https://github.com/sourcefuse/terraform-aws-arc-bootstrap/blob/main/catalog-info.yml
+      rules:
+        - allow: [ Component ]
+
+    - type: url
       target: https://github.com/sourcefuse/terraform-aws-arc-cloud-custodian/blob/main/catalog-info.yml
       rules:
         - allow: [ Component ]


### PR DESCRIPTION
Remove old templates from app config (Seed Templates and Repos Are Incorrect)

ARC-107

## Description

Seed repos and templates are out of date with upstream changes to the Git repos. Update app-config.yml remove out dated templates.
Removed react boilerplate and terraform-aws-arc-bootstrap templates from app-config.yml.

Fixes # (issue)
ARC-107

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
