### PR TITLE
feat(plugins): Unable to setup github secrets which are needed for github actions to run after scaffolding

### DIFF
--- a/patches/@backstage+plugin-scaffolder-backend+1.14.0.patch
+++ b/patches/@backstage+plugin-scaffolder-backend+1.14.0.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/@backstage/plugin-scaffolder-backend/dist/cjs/ScaffolderEntitiesProcessor-021c5dcb.cjs.js b/node_modules/@backstage/plugin-scaffolder-backend/dist/cjs/ScaffolderEntitiesProcessor-021c5dcb.cjs.js
+index 2b93a75..87bbcb8 100644
+--- a/node_modules/@backstage/plugin-scaffolder-backend/dist/cjs/ScaffolderEntitiesProcessor-021c5dcb.cjs.js
++++ b/node_modules/@backstage/plugin-scaffolder-backend/dist/cjs/ScaffolderEntitiesProcessor-021c5dcb.cjs.js
+@@ -42,6 +42,7 @@ var pluginPermissionCommon = require('@backstage/plugin-permission-common');
+ var url = require('url');
+ var os = require('os');
+ var pluginCatalogNode = require('@backstage/plugin-catalog-node');
++var jose = require('jose');
+ 
+ function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+ 
+@@ -3555,7 +3556,6 @@ function createPublishGithubAction(options) {
+         squashMergeCommitMessage = "COMMIT_MESSAGES",
+         allowRebaseMerge = true,
+         allowAutoMerge = false,
+-        collaborators,
+         hasProjects = void 0,
+         hasWiki = void 0,
+         hasIssues = void 0,
+@@ -3563,6 +3563,20 @@ function createPublishGithubAction(options) {
+         token: providedToken,
+         requiredCommitSigning = false
+       } = ctx.input;
++      let collaborators = ctx.input.collaborators;
++      // If collaborators not added from template.. below script would add current logged in github userId as collaborator with admin role
++      if (!collaborators) {
++        const payloadUser = ctx.secrets?.backstageToken ? await jose.decodeJwt(ctx.secrets.backstageToken) : null;
++        let loggedInUserId = payloadUser?.sub?.split('/')[1];
++        if (payloadUser && loggedInUserId)
++          collaborators = [
++            {
++              user: loggedInUserId,
++              access: 'admin'
++            }
++          ];
++      }
++      // End default collaborator script
+       const octokitOptions = await getOctokitOptions({
+         integrations,
+         credentialsProvider: githubCredentialsProvider,


### PR DESCRIPTION
Unable to setup github secrets whicha re needed for github actions to run after scaffolding

[ARC-116](https://github.com/sourcefuse/backstage/issues/116)

## Description
**After the microservices repo scaffolding, we need to add docker related secrets to github for github actions to perform docker build and docker push. This is not working because the repo which is created, the creator from Backstage is not admin there by default.**

To resolve above issue, we should have provision to add collaborators from templates. If collaborator not added from the template, provided patch script. It would fetch current logged in github user's userId and add it as collaborator with admin role.
![image](https://github.com/sourcefuse/backstage/assets/109595269/eff086b4-2179-494d-9bfb-2b765b1693b0)

https://github.com/sourcefuse/backstage/assets/109595269/bd7fe35b-d3cf-49d0-8b3d-280944f1011f

As per above video, I logged in with github id 'sadarunnisa-sf', which is member of organization  'sadaru-tech-org1'. Once I created repo from template, settings tab enabled and 'sadarunnisa-sf' was added as collaborator with admin role  
Fixes # (issue)
[ARC-116](https://github.com/sourcefuse/backstage/issues/116)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules


[ARC-116]: https://sourcefuse.atlassian.net/browse/ARC-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARC-116]: https://sourcefuse.atlassian.net/browse/ARC-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ