### PR TITLE
test(templates): Cypress test to execute arc lambda boilerplate template

### DIFF
--- a/packages/app/cypress.json
+++ b/packages/app/cypress.json
@@ -2,5 +2,9 @@
   "baseUrl": "http://localhost:3001",
   "fixturesFolder": false,
   "pluginsFile": false,
-  "retries": 3
+  "retries": 3,
+  "env": {
+    "FRONTEND_BASE_URL":"http://localhost:3000",
+    "ORGANIZATION":"sadaru-tech-org1"
+  }
 }

--- a/packages/app/cypress/integration/templates/arc-lambda-boilerplate-template-execution.spec.js
+++ b/packages/app/cypress/integration/templates/arc-lambda-boilerplate-template-execution.spec.js
@@ -1,0 +1,36 @@
+describe('SourceFuse Backstage Template Execution', () => {
+  const frontendBaseUrl = Cypress.env('FRONTEND_BASE_URL');
+  const templateUrl = `${frontendBaseUrl}/create/templates/default/arc-lambda-boilerplate`;
+  const randVal = Math.floor(Math.random() * 1000);
+  const timeOutVal = 50000;
+  it('should execute the template ARC Lambda Boilerplate', () => {
+    // Visit the page where the template can be executed
+    cy.visit(templateUrl);
+    cy.contains('Create a New Component', { timeout: timeOutVal }).should(
+      'be.visible',
+    );
+    cy.get('input#root_function_id', { timeout: 50000 }).type(
+      `lambda-bolierplate-${randVal}`,
+    );
+    cy.get('input#root_backstage_namespace').type(
+      `nm-lambda-bolierplate-${randVal}`,
+    );
+    cy.get('input#root_description').type(
+      `Description of lambda-bolierplate-${randVal}`,
+    );
+    cy.get('form')
+      .should('have.class', 'rjsf')
+      .should('have.length', 1)
+      .submit({ timeout: timeOutVal });
+    cy.get('input#ownerInput').type(Cypress.env('ORGANIZATION'));
+    cy.get('input#repoNameInput').type(`repo-lambda-bolierplate-${randVal}`);
+    cy.get('form')
+      .should('have.class', 'rjsf')
+      .should('have.length', 1)
+      .submit({ timeout: timeOutVal });
+    cy.get('button:last').click({ timeout: timeOutVal });
+    cy.contains('Finished step Register', { timeout: timeOutVal }).should(
+      'be.visible',
+    );
+  });
+});


### PR DESCRIPTION
Cypress test to execute ARC lambda boilerplate template

## Description

We need to execute cypress test to execute templates. Worked on cypress integration test to execute ARC lambda boilerplate template.

https://github.com/sourcefuse/backstage/assets/109595269/9cfce4ae-4e6e-4de9-8f81-e203952dc34e

Fixes # (issue)
Cypress test for ARC lambda boilerplate template

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
