### PR TITLE
feat(backend): Github based permission management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+.history

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -302,6 +302,7 @@ catalog:
 # kubernetes:
   # see https://backstage.io/docs/features/kubernetes/configuration for kubernetes configuration options
 # see https://backstage.io/docs/permissions/getting-started for more on the permission framework
-# permission:
-#   # setting this to `false` will disable permissions
-#   enabled: true
+
+## setting this to `false` will disable permissions
+permission:
+  enabled: true

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -64,7 +64,8 @@
     "pg": "^8.11.3",
     "winston": "^3.2.1",
     "workerpool": "^6.2.1",
-    "yeoman-environment": "^3.9.1"
+    "yeoman-environment": "^3.9.1",
+    "octokit": "^3.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.27.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -65,7 +65,8 @@
     "winston": "^3.2.1",
     "workerpool": "^6.2.1",
     "yeoman-environment": "^3.9.1",
-    "octokit": "^3.0.0"
+    "octokit": "^3.0.0",
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@backstage/cli": "^0.27.1",
@@ -73,7 +74,8 @@
     "@types/express": "^4.17.6",
     "@types/express-serve-static-core": "^4.17.5",
     "@types/luxon": "^2.0.4",
-    "@types/workerpool": "^6.1.0"
+    "@types/workerpool": "^6.1.0",
+    "@types/lodash": "4.17.12"
   },
   "files": [
     "dist"

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,6 +1,4 @@
-
 import { createBackend } from '@backstage/backend-defaults';
-
 
 import { createBackendModule } from '@backstage/backend-plugin-api';
 
@@ -18,14 +16,13 @@ const scaffolderModuleCustomExtensions = createBackendModule({
       },
       async init({ scaffolder }) {
         scaffolder.addActions(
-           createMicroserviceAction(),
-           createScaffoldAction()
+          createMicroserviceAction(),
+          createScaffoldAction(),
         );
-      }
-    })
+      },
+    });
   },
 });
-
 
 const backend = createBackend();
 
@@ -44,13 +41,9 @@ backend.add(
 // See https://backstage.io/docs/features/software-catalog/configuration#subscribing-to-catalog-errors
 backend.add(import('@backstage/plugin-catalog-backend-module-logs'));
 
-
 // permission plugin
 backend.add(import('@backstage/plugin-permission-backend/alpha'));
-// See https://backstage.io/docs/permissions/getting-started for how to create your own permission policy
-backend.add(
-  import('@backstage/plugin-permission-backend-module-allow-all-policy'),
-);
+backend.add(import('./plugins/permission'));
 
 // search plugin
 backend.add(import('@backstage/plugin-search-backend/alpha'));
@@ -63,7 +56,6 @@ backend.add(import('@backstage/plugin-search-backend-module-techdocs/alpha'));
 
 backend.add(import('@internal/backstage-plugin-access-validate-backend'));
 backend.add(import('@backstage/plugin-scaffolder-backend-module-github'));
-
 
 backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
 backend.add(scaffolderModuleCustomExtensions);

--- a/packages/backend/src/plugins/permission.ts
+++ b/packages/backend/src/plugins/permission.ts
@@ -1,0 +1,186 @@
+import {
+  AuthorizeResult,
+  isPermission,
+  type PolicyDecision,
+} from '@backstage/plugin-permission-common';
+import type {
+  PermissionPolicy,
+  PolicyQuery,
+} from '@backstage/plugin-permission-node';
+import {
+  catalogConditions,
+  createCatalogConditionalDecision,
+} from '@backstage/plugin-catalog-backend/alpha';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
+import type { BackstageIdentityResponse } from '@backstage/plugin-auth-node';
+import type { PaginatingEndpoints } from '@octokit/plugin-paginate-rest';
+import { parseEntityRef } from '@backstage/catalog-model';
+import {
+  createBackendModule,
+  type AuthService,
+  type CacheService,
+  type DiscoveryService,
+} from '@backstage/backend-plugin-api';
+import { policyExtensionPoint } from '@backstage/plugin-permission-node/alpha';
+import { coreServices } from '@backstage/backend-plugin-api';
+import { Octokit } from 'octokit';
+
+class RequestPermissionPolicy implements PermissionPolicy {
+  readonly orgRepositories: Promise<
+    PaginatingEndpoints['GET /orgs/{org}/repos']['response']['data']
+  >;
+  readonly catalogRepos: Promise<Set<string>>;
+  readonly userRepoPermissions: Record<string, Array<string>> = {};
+
+  constructor(
+    protected readonly tokenManager: AuthService,
+    protected readonly discovery: DiscoveryService,
+    protected readonly cache: CacheService,
+    protected readonly octokit: Octokit,
+  ) {
+    this.orgRepositories = this.fetchOrganizationRepos();
+    this.catalogRepos = this.fetchCatalog();
+  }
+
+  async handle(
+    request: PolicyQuery,
+    user?: BackstageIdentityResponse,
+  ): Promise<PolicyDecision> {
+    console.debug(request);
+    console.time('*********************Permission Validation**************');
+    if (!user?.identity) {
+      console.error('not able to found the name', user);
+      return { result: AuthorizeResult.DENY };
+    }
+
+    const userPermission = await this.resolveAuthorizedRepoList(
+      user.identity.userEntityRef,
+    );
+
+    if (
+      userPermission.length &&
+      isPermission(request.permission, catalogEntityReadPermission)
+    ) {
+      console.timeEnd(
+        '*********************Permission Validation**************',
+      );
+
+      return createCatalogConditionalDecision(request.permission, {
+        //@ts-ignore
+        anyOf: userPermission.map(value =>
+          //@ts-ignore
+          catalogConditions.hasMetadata({ key: 'name', value }),
+        ),
+      });
+    }
+    console.timeEnd('*********************Permission Validation**************');
+
+    return { result: AuthorizeResult.ALLOW };
+  }
+
+  protected async fetchOrganizationRepos() {
+    console.time('******************Github OrgRepoList*******');
+    const out: PaginatingEndpoints['GET /orgs/{org}/repos']['response']['data'] =
+      [];
+    for await (const { data } of this.octokit.paginate.iterator(
+      'GET /orgs/{org}/repos',
+      {
+        per_page: 100,
+        org: String(process.env.GITHUB_ORGANIZATION),
+      },
+    )) {
+      //! will use status or header to validate success
+      out.push(...data);
+    }
+    console.timeEnd('******************Github OrgRepoList*******');
+    return out;
+  }
+
+  protected async fetchCatalog() {
+    const base = await this.discovery.getBaseUrl('catalog');
+    const { token } = await this.tokenManager.getPluginRequestToken({
+      onBehalfOf: await this.tokenManager.getOwnServiceCredentials(),
+      targetPluginId: 'catalog',
+    });
+
+    const url = `${base}/entities?filter=kind=component`;
+
+    const req = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await req.json();
+    // Get Name a repo name not the repo full_name
+    return new Set<string>(data.map((cl: any) => cl.metadata.name));
+  }
+
+  protected async resolveAuthorizedRepoList(userEntityRef: string) {
+    const usernameEntity = parseEntityRef(userEntityRef);
+
+    if (!(userEntityRef in this.userRepoPermissions)) {
+      const batch = [];
+      this.userRepoPermissions[userEntityRef] = [];
+      const catalogRepos = await this.catalogRepos;
+      const orgRepos = await this.orgRepositories;
+      // Filtering out repo which is logged in the Catalog meta with just name of the repo
+      const repositories = orgRepos.filter(r => catalogRepos.has(r.name));
+      const privateCatalogRepos = repositories.filter(r => r.private);
+      const publicCatalogRepos = repositories.filter(r => r.private === false);
+      for (const repo of publicCatalogRepos) {
+        this.userRepoPermissions[userEntityRef].push(repo.name);
+      }
+
+      for (const repo of privateCatalogRepos) {
+        batch.push(
+          this.octokit.rest.repos
+            .getCollaboratorPermissionLevel({
+              owner: String(process.env.GITHUB_ORGANIZATION),
+              repo: repo.name,
+              username: usernameEntity.name,
+            })
+            .then(resp => ({
+              repo,
+              ...resp.data,
+            })),
+          //! need to add header check
+        );
+        if (batch.length > 10) {
+          const permissions = await Promise.all(batch);
+          for (const permission of permissions) {
+            this.userRepoPermissions[userEntityRef].push(permission.repo.name);
+          }
+          batch.length = 0;
+        }
+      }
+      //! log any meta name which is not include that means there is issue in the meta name
+    }
+
+    return this.userRepoPermissions[userEntityRef];
+  }
+}
+
+export default createBackendModule({
+  pluginId: 'permission',
+  moduleId: 'permission-policy',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        auth: coreServices.auth,
+        discovery: coreServices.discovery,
+        cache: coreServices.cache,
+        policy: policyExtensionPoint,
+      },
+      async init({ policy, cache, discovery, auth }) {
+        const octokit = new Octokit({
+          auth: String(process.env.GITHUB_TOKEN),
+          // throttle: {},
+        });
+        policy.setPolicy(
+          new RequestPermissionPolicy(auth, discovery, cache, octokit),
+        );
+      },
+    });
+  },
+});


### PR DESCRIPTION
## Description

This PR introduces a new feature to the Backstage GitHub Permission Plugin. It enables GitHub-based permissions to be mapped with Backstage's permission framework. This allows for more granular control and security when integrating GitHub permissions with Backstage applications.

Fixes #187

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [X] Any dependent changes have been merged and published in downstream modules
